### PR TITLE
remove erroneous ng-click from submit button

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       <div class="tc pvm bg-dark-gray">
         <form ng-submit="getGitInfo()">
           <input type="text" id="ghusername" autofocus ng-model="username" placeholder="Github username..." class="mrm f4 phm pvs br2 ba b--white">
-          <button type="submit" id="ghsubmitbtn" ng-click="getGitInfo()" class="btn f4 bg-white gray pvs phm b--white">Go</button>
+          <button type="submit" id="ghsubmitbtn" class="btn f4 bg-white gray pvs phm b--white">Go</button>
         </form>
         <div id="ghapidata"></div>
       </div>


### PR DESCRIPTION
Realised i'd `ng-click` on the submit button, it's no longer needed cos the submit event bubbles up to the form. Removed
